### PR TITLE
chore: add publish workflow and changeset for npm publishing

### DIFF
--- a/.changeset/two-suits-report.md
+++ b/.changeset/two-suits-report.md
@@ -1,0 +1,5 @@
+---
+"temis": patch
+---
+
+npm publish ready

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,60 @@
+---
+name: Publish
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+
+permissions: {}
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  release:
+    name: Release
+
+    runs-on: ubuntu-latest
+
+    timeout-minutes: 5
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@e3d2460bbb42d7710191569f88069044cfb9d8cf # v4.2.2
+
+      - name: Run actionlint
+        run: |
+          set -x
+          docker run --rm -v "$(pwd):$(pwd)" -w "$(pwd)" rhysd/actionlint:1.7.3
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
+        with:
+          version: 10
+          run_install: false
+
+      - name: Install Node.js
+        uses: actions/setup-node@1d0ff469b7ec7b3cb9d8673fde0c81c44821de2a # v4.2.0
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Publish npmjs
+        run: |
+          set -x
+            pnpm publish --no-git-checks
+        env:
+            NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -23,5 +23,8 @@
   },
   "engines": {
     "node": ">=22"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }


### PR DESCRIPTION
This pull request includes several changes to facilitate the npm publishing process and configure a GitHub Actions workflow for automated releases. The most important changes include the addition of a new workflow configuration, updates to the `package.json` file, and a changeset file indicating a patch release.

### Workflow Configuration:

* [`.github/workflows/publish.yml`](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R1-R60): Added a new GitHub Actions workflow to automate the npm publishing process. This workflow includes steps for checking out the repository, running actionlint, installing pnpm and Node.js, installing dependencies, and publishing to npm.

### Package Configuration:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R26-R28): Updated to include `publishConfig` with `access` set to `public`, ensuring that the package is published publicly.
