### PR TITLE
fix(configs/eslint): 🐛 remove eslint-plugin-oxlint syntax (#39)

### DIFF
--- a/configs/eslint/eslint.config.js
+++ b/configs/eslint/eslint.config.js
@@ -19,7 +19,6 @@ import pluginBoundaries from "eslint-plugin-boundaries";
 import perfectionist from "eslint-plugin-perfectionist";
 import importAccess from "eslint-plugin-import-access/flat-config";
 import playwright from "eslint-plugin-playwright";
-import oxlint from "eslint-plugin-oxlint";
 
 export default defineConfig([
   {
@@ -481,5 +480,4 @@ export default defineConfig([
     language: "css/css",
     extends: ["css/recommended"],
   },
-  ...oxlint.buildFromOxlintConfigFile("../oxlint/.oxlintrc.json"),
 ]);


### PR DESCRIPTION
Fixes #39